### PR TITLE
Adjust delimiter to allow csv import of arrays

### DIFF
--- a/server/src/dev-data/seeds/csvGenerator.js
+++ b/server/src/dev-data/seeds/csvGenerator.js
@@ -14,13 +14,13 @@ const { generateMockCSVReward } = require('./generator');
 // our stream that will be passed as the first argument for our generator function as 'writer'
 const writeProjects = fs.createWriteStream('projects.csv');
 // write our CSV headers
-writeProjects.write('rewardID,title,pledgeAmount,description,deliveryMonth,deliveryYear,shippingType,rewardQuantity,timeLimit,randomId,rewardItems\n','utf8');
+writeProjects.write('rewardID;title;pledgeAmount;description;deliveryMonth;deliveryYear;shippingType;rewardQuantity;timeLimit;randomId;rewardItems\n','utf8');
 
 const multibar = new cliProgress.MultiBar({ clearOnComplete: false, hideCursor: true }, cliProgress.Presets.rect);
 
 function writeTenMillionProjects(writer, encoding, callback) {
 
-  const numOfRecords = 10000000;
+  const numOfRecords = 100;
   //Start CLI progress bar
   const pBar = multibar.create(numOfRecords, 0);
   // const rBar = multibar.create(numOfRecords * (minRewards + maxRewards / 2), 0);

--- a/server/src/dev-data/seeds/generator.js
+++ b/server/src/dev-data/seeds/generator.js
@@ -60,19 +60,11 @@ module.exports.generateMockCSVReward = (projectID, rewardID) => {
   const shippingType = faker.company.bsAdjective();
   const rewardQuantity = Math.floor(Math.random() * (500 - 1 + 1)) + 1;
   const timeLimit = faker.random.number();
-  const projectId = faker.random.number();
+  const randomId = faker.random.number();
   const rewardItems = Array.from({ length: random.int(1, 6) }, () =>
     faker.commerce.product()
   ).join(',')
-  // format each CSV line
-  return `${projectID}, ${rewardID}, ${title},
-    ${pledgeAmount},
-    ${description},
-    ${deliveryMonth},
-    ${deliveryYear},
-    ${shippingType},
-    ${rewardQuantity},
-    ${timeLimit},
-    ${projectId},
-    ${rewardItems}\n`;
+  // format each CSV line ${projectID};
+  return `${rewardID};${title};${pledgeAmount};${description};${deliveryMonth};${deliveryYear};${shippingType};${rewardQuantity};${timeLimit};${randomId};` + "{" + rewardItems + "}" + `\n`;
+
 };


### PR DESCRIPTION
* Noticed that I had newlines within my template literals which was creating issues with my csv formatting. Removing all spaces corrected this issue
* When importing my csv into Postgres, my last item in each row was an array, which is also separated by commas. This array was being interpreted on import as additional columns that should be added where the schema did not have room. Changing the delimiter in import to use semi-colons allowed me to use commas within the array and get those values stored inside Postgres as arrays. Of note was that arrays in Postgres are wrapped in curly braces.